### PR TITLE
refactor: Remove review jobs from reusable CI pipeline

### DIFF
--- a/.github/workflows/ci-pipeline-reusable.yml
+++ b/.github/workflows/ci-pipeline-reusable.yml
@@ -7,21 +7,6 @@ on:
         description: 'Node.js version'
         type: string
         default: '22'
-      actions_version:
-        description: 'claude-code-actions version/ref'
-        type: string
-        default: 'v1.1.2'
-      skip_reviews:
-        description: 'Skip AI reviews (for testing)'
-        type: boolean
-        default: false
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN:
-        required: true
-      CONSTELLOS_APP_ID:
-        required: false
-      CONSTELLOS_APP_PRIVATE_KEY:
-        required: false
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref_name }}
@@ -29,14 +14,13 @@ concurrency:
 
 env:
   NODE_VERSION: ${{ inputs.node_version }}
-  ACTIONS_VERSION: v1.1.2
 
 jobs:
   # ============================================
   # STATIC ANALYSIS
   # ============================================
   lint:
-    name: "Static Analysis / Lint (ESLint)"
+    name: Lint (ESLint)
     runs-on: ubuntu-latest
     outputs:
       has_app: ${{ steps.detect.outputs.has_app }}
@@ -88,7 +72,7 @@ jobs:
           $PM run lint
 
   types:
-    name: "Static Analysis / Types (TypeScript)"
+    name: Types (TypeScript)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -143,7 +127,7 @@ jobs:
   # TESTS (requires Static Analysis)
   # ============================================
   unit:
-    name: "Tests / Unit (Vitest)"
+    name: Unit Tests (Vitest)
     needs: [lint, types]
     runs-on: ubuntu-latest
     outputs:
@@ -223,7 +207,7 @@ jobs:
           $PM run test -- --passWithNoTests || npx vitest run --passWithNoTests
 
   e2e:
-    name: "Tests / E2E (Playwright)"
+    name: E2E Tests (Playwright)
     needs: [lint, unit]
     if: needs.lint.outputs.has_app == 'true'
     runs-on: ubuntu-latest
@@ -319,216 +303,3 @@ jobs:
           name: playwright-screenshots-${{ github.sha }}
           path: .claude/screenshots/
           retention-days: 7
-
-  # ============================================
-  # REVIEWS (requires Tests, PR only)
-  # ============================================
-  requirements:
-    name: "Reviews / Requirements"
-    needs: [unit, e2e]
-    if: github.event_name == 'pull_request' && !failure() && !cancelled() && inputs.skip_reviews != true
-    runs-on: ubuntu-latest
-    outputs:
-      passed: ${{ steps.review.outputs.passed }}
-      result: ${{ steps.review.outputs.result }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.CONSTELLOS_APP_ID }}
-          private-key: ${{ secrets.CONSTELLOS_APP_PRIVATE_KEY }}
-          skip-token-revoke: true
-
-      - name: Run requirements review
-        id: review
-        uses: constellos/claude-code-actions/.github/actions/requirements-reviewer@v1.1.2
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          pr_number: ${{ github.event.pull_request.number }}
-          branch: ${{ github.head_ref }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update comment
-        if: always()
-        uses: constellos/claude-code-actions/.github/actions/review-comment@v1.1.2
-        with:
-          review_name: Requirements
-          passed: ${{ steps.review.outputs.passed }}
-          result_json: ${{ steps.review.outputs.result }}
-          pr_number: ${{ github.event.pull_request.number }}
-          sha: ${{ github.sha }}
-          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-
-  code-quality:
-    name: "Reviews / Code Quality"
-    needs: [requirements]
-    if: always() && github.event_name == 'pull_request' && needs.requirements.outputs.passed == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      passed: ${{ steps.review.outputs.passed }}
-      result: ${{ steps.review.outputs.result }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.CONSTELLOS_APP_ID }}
-          private-key: ${{ secrets.CONSTELLOS_APP_PRIVATE_KEY }}
-          skip-token-revoke: true
-
-      - name: Run code quality review
-        id: review
-        uses: constellos/claude-code-actions/.github/actions/code-quality-reviewer@v1.1.2
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          pr_number: ${{ github.event.pull_request.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update comment
-        if: always()
-        uses: constellos/claude-code-actions/.github/actions/review-comment@v1.1.2
-        with:
-          review_name: Code Quality
-          passed: ${{ steps.review.outputs.passed }}
-          result_json: ${{ steps.review.outputs.result }}
-          pr_number: ${{ github.event.pull_request.number }}
-          sha: ${{ github.sha }}
-          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-
-  context:
-    name: "Reviews / Context"
-    needs: [requirements]
-    if: always() && github.event_name == 'pull_request' && needs.requirements.outputs.passed == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      passed: ${{ steps.review.outputs.passed }}
-      result: ${{ steps.review.outputs.result }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.CONSTELLOS_APP_ID }}
-          private-key: ${{ secrets.CONSTELLOS_APP_PRIVATE_KEY }}
-          skip-token-revoke: true
-
-      - name: Run context review
-        id: review
-        uses: constellos/claude-code-actions/.github/actions/context-reviewer@v1.1.2
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          pr_number: ${{ github.event.pull_request.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update comment
-        if: always()
-        uses: constellos/claude-code-actions/.github/actions/review-comment@v1.1.2
-        with:
-          review_name: Context
-          passed: ${{ steps.review.outputs.passed }}
-          result_json: ${{ steps.review.outputs.result }}
-          pr_number: ${{ github.event.pull_request.number }}
-          sha: ${{ github.sha }}
-          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-
-  visual:
-    name: "Reviews / Visual"
-    needs: [lint, requirements, e2e]
-    if: always() && github.event_name == 'pull_request' && needs.lint.outputs.has_app == 'true' && needs.requirements.outputs.passed == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      passed: ${{ steps.review.outputs.passed }}
-      result: ${{ steps.review.outputs.result }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: playwright-screenshots-${{ github.sha }}
-          path: .claude/screenshots/
-        continue-on-error: true
-
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.CONSTELLOS_APP_ID }}
-          private-key: ${{ secrets.CONSTELLOS_APP_PRIVATE_KEY }}
-          skip-token-revoke: true
-
-      - name: Run visual review
-        id: review
-        uses: constellos/claude-code-actions/.github/actions/visual-reviewer@v1.1.2
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          pr_number: ${{ github.event.pull_request.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update comment
-        if: always()
-        uses: constellos/claude-code-actions/.github/actions/review-comment@v1.1.2
-        with:
-          review_name: Visual
-          passed: ${{ steps.review.outputs.passed }}
-          result_json: ${{ steps.review.outputs.result }}
-          pr_number: ${{ github.event.pull_request.number }}
-          sha: ${{ github.sha }}
-          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-
-  ux:
-    name: "Reviews / UX"
-    needs: [lint, requirements, e2e]
-    if: always() && github.event_name == 'pull_request' && needs.lint.outputs.has_app == 'true' && needs.requirements.outputs.passed == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      passed: ${{ steps.review.outputs.passed }}
-      result: ${{ steps.review.outputs.result }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        continue-on-error: true
-        with:
-          app-id: ${{ secrets.CONSTELLOS_APP_ID }}
-          private-key: ${{ secrets.CONSTELLOS_APP_PRIVATE_KEY }}
-          skip-token-revoke: true
-
-      - name: Run UX review
-        id: review
-        uses: constellos/claude-code-actions/.github/actions/ux-reviewer@v1.1.2
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          pr_number: ${{ github.event.pull_request.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update comment
-        if: always()
-        uses: constellos/claude-code-actions/.github/actions/review-comment@v1.1.2
-        with:
-          review_name: UX
-          passed: ${{ steps.review.outputs.passed }}
-          result_json: ${{ steps.review.outputs.result }}
-          pr_number: ${{ github.event.pull_request.number }}
-          sha: ${{ github.sha }}
-          github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Reviews are now handled by a separate Constellos workflow in each repo that triggers after CI completes via `workflow_run`.

This reusable CI pipeline now only contains:
- `lint`: Lint (ESLint)
- `types`: Types (TypeScript)
- `unit`: Unit Tests (Vitest)
- `e2e`: E2E Tests (Playwright)

## Why
This change supports the new architecture where:
1. CI runs first (lint, types, tests)
2. Constellos reviews trigger AFTER CI passes via `workflow_run`
3. Clean naming in GitHub UI: `CI / Lint` and `Constellos / Requirements Review`

## Related
- constellos/constellos#22 - Restructures the main repo workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)