### PR TITLE
fix: Add workflow_run trigger and simplify CI check names

### DIFF
--- a/.github/workflows/ci-pipeline-reusable.yml
+++ b/.github/workflows/ci-pipeline-reusable.yml
@@ -20,7 +20,7 @@ jobs:
   # STATIC ANALYSIS
   # ============================================
   lint:
-    name: "Static Analysis / Lint (ESLint)"
+    name: "Lint"
     runs-on: ubuntu-latest
     outputs:
       has_app: ${{ steps.detect.outputs.has_app }}
@@ -72,7 +72,7 @@ jobs:
           $PM run lint
 
   types:
-    name: "Static Analysis / Types (TypeScript)"
+    name: "Types"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
   # TESTS (requires Static Analysis)
   # ============================================
   unit:
-    name: "Tests / Unit (Vitest)"
+    name: "Unit"
     needs: [lint, types]
     runs-on: ubuntu-latest
     outputs:
@@ -207,7 +207,7 @@ jobs:
           $PM run test -- --passWithNoTests || npx vitest run --passWithNoTests
 
   e2e:
-    name: "Tests / E2E (Playwright)"
+    name: "E2E"
     needs: [lint, unit]
     if: needs.lint.outputs.has_app == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/constellos.yml
+++ b/.github/workflows/constellos.yml
@@ -1,6 +1,9 @@
 name: Constellos
 
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -29,22 +32,63 @@ permissions:
   checks: write
 
 jobs:
-  # Map inputs to outputs for consistency with other jobs
+  # Get PR info from workflow_run event or workflow_dispatch inputs
   context:
     name: Get PR Context
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request')
     outputs:
-      pr_number: ${{ github.event.inputs.pr_number }}
-      sha: ${{ github.event.inputs.sha }}
-      branch: ${{ github.event.inputs.branch }}
+      pr_number: ${{ steps.pr.outputs.number }}
+      sha: ${{ steps.pr.outputs.sha }}
+      branch: ${{ steps.pr.outputs.branch }}
       has_app: 'true'
     steps:
+      - name: Get PR info (workflow_run)
+        if: github.event_name == 'workflow_run'
+        id: workflow-run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs || prs.length === 0) {
+              core.setFailed('No PR found in workflow run');
+              return;
+            }
+            const pr = prs[0];
+            core.setOutput('number', pr.number);
+            core.setOutput('sha', context.payload.workflow_run.head_sha);
+            core.setOutput('branch', pr.head.ref);
+
+      - name: Get PR info (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: dispatch
+        run: |
+          echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "sha=${{ github.event.inputs.sha }}" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+
+      - name: Set outputs
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "number=${{ steps.workflow-run.outputs.number }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ steps.workflow-run.outputs.sha }}" >> $GITHUB_OUTPUT
+            echo "branch=${{ steps.workflow-run.outputs.branch }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ steps.dispatch.outputs.number }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ steps.dispatch.outputs.sha }}" >> $GITHUB_OUTPUT
+            echo "branch=${{ steps.dispatch.outputs.branch }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Log context
         run: |
-          echo "PR: ${{ github.event.inputs.pr_number }}"
-          echo "Branch: ${{ github.event.inputs.branch }}"
-          echo "SHA: ${{ github.event.inputs.sha }}"
-          echo "Triggered by: ${{ github.event.inputs.triggered_by }}"
+          echo "Event: ${{ github.event_name }}"
+          echo "PR: ${{ steps.pr.outputs.number }}"
+          echo "Branch: ${{ steps.pr.outputs.branch }}"
+          echo "SHA: ${{ steps.pr.outputs.sha }}"
 
   requirements:
     name: Requirements Review


### PR DESCRIPTION
## Summary

- Adds `workflow_run` trigger to `constellos.yml` so AI reviews trigger automatically after CI completes on PRs
- Updates context job to handle both `workflow_run` and `workflow_dispatch` events with proper PR info extraction
- Simplifies job display names in `ci-pipeline-reusable.yml` for cleaner check names

## Changes

### `constellos.yml`
- Added `workflow_run` trigger listening for "CI" workflow completion
- Added condition to context job: runs on `workflow_dispatch` OR successful PR-triggered CI
- Added GitHub Script step to extract PR info from `workflow_run` event
- Maintains backward compatibility with existing `workflow_dispatch` inputs

### `ci-pipeline-reusable.yml`
| Before | After |
|--------|-------|
| `Static Analysis / Lint (ESLint)` | `Lint` |
| `Static Analysis / Types (TypeScript)` | `Types` |
| `Tests / Unit (Vitest)` | `Unit` |
| `Tests / E2E (Playwright)` | `E2E` |

## Test plan

- [ ] Push changes to `constellos/.github` repo
- [ ] Create/update a PR in `nodes-md`
- [ ] Verify CI checks show as `CI / Lint`, `CI / Types`, `CI / Unit`, `CI / E2E`
- [ ] After CI completes, verify AI reviews trigger automatically

Fixes constellos/constellos-actions#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)